### PR TITLE
Added support for redis database selection

### DIFF
--- a/files/app/etc/env.php.twig
+++ b/files/app/etc/env.php.twig
@@ -59,7 +59,7 @@ return [
             'password' => '{{ redis_session_password ? redis_session_password : ''}}',
             'timeout' => '2.5',
             'persistent_identifier' => '',
-            'database' => '0',
+            'database' => '{{ redis_session_database ? redis_session_database : '0'}}',
             'compression_threshold' => '2048',
             'compression_library' => 'gzip',
             'log_level' => '1',
@@ -89,7 +89,7 @@ return [
                 'backend' => 'Cm_Cache_Backend_Redis',
                 'backend_options' => [
                     'server' => '{{ redis_object_host }}',
-                    'database' => '0',
+                    'database' => '{{ redis_object_database ? redis_object_database : '0'}}',
                     'port' => '{{ redis_object_port }}',
                     'password' => '{{ redis_object_password ? redis_object_password : ''}}',
                 ],
@@ -103,7 +103,7 @@ return [
                     'server' => '{{ redis_fpc_host }}',
                     'port' => '{{ redis_fpc_port }}',
                     'password' => '{{ redis_fpc_password ? redis_fpc_password : ''}}',
-                    'database' => '0',
+                    'database' => '{{ redis_fpc_database ? redis_fpc_database : '0'}}',
                     'compress_data' => '0'
                 ],
             ],


### PR DESCRIPTION
If you set: 
redis_object_database
redis_session_database
redis_fpc_database

It will now use that value to populate the env.php. This is useful if you want to use a single redis instance.