### PR TITLE
updated env.php.twig max_concurrency to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Conductor: Magento 2 Platform Support Changelog
 ==============================================
 
+# 0.9.7
+- updated env.php.twig max_concurrency to 20
+
 # 0.9.6
 - Added ability to set x-frame-options header in app/etc/env.php
 

--- a/files/app/etc/env.php.twig
+++ b/files/app/etc/env.php.twig
@@ -63,7 +63,7 @@ return [
             'compression_threshold' => '2048',
             'compression_library' => 'gzip',
             'log_level' => '1',
-            'max_concurrency' => '6',
+            'max_concurrency' => '20',
             'break_after_frontend' => '5',
             'break_after_adminhtml' => '30',
             'first_lifetime' => '600',


### PR DESCRIPTION
Update to resolve redis session failures on Magento 2 with php 7.2+