### PR TITLE
Update cachetool URL to use HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Conductor: Magento 2 Platform Support Changelog
 ==============================================
 
+# 0.9.10 (unreleased)
+- Updated opcache command in dist file to https, run php instead of php71, and include -L curl flag
+
 # 0.9.9
 - Added ability to set Magento store configuration via app/etc/env.php
 

--- a/config/dist/deployment-plans.yaml
+++ b/config/dist/deployment-plans.yaml
@@ -195,7 +195,7 @@ application_orchestration:
               class: ConductorAppOrchestration\Deploy\Command\MakeBuildCurrentCommand
             reset-opcache:
               conditions: [code]
-              command: curl -sO http://gordalina.github.io/cachetool/downloads/cachetool.phar && php71 cachetool.phar opcache:reset
+              command: curl -sOL https://gordalina.github.io/cachetool/downloads/cachetool.phar && php cachetool.phar opcache:reset
             run-installers:
               run_in_code_root: true
               conditions: [code, refresh]


### PR DESCRIPTION
Github's URLs for file access now requires HTTPS. I've also added a flag to redirect in case these URLs change in the future.